### PR TITLE
[ESatresplayer] Fixes required per the latest update of Atresplayer

### DIFF
--- a/common/m3u.py
+++ b/common/m3u.py
@@ -25,16 +25,16 @@ class M3UPlaylist:
         if expectExtm3u and not self.extm3u:
             raise ValueError("Expected #EXTM3U header")
 
-        attrs = {}
+        attrs = []
         for line in lines:
             if not line:
                 continue
             m = re.match('#([^:]+):?(.*)', line)
             if m:
-                attrs[m[1]] = m[2].strip()
+                attrs += [(m[1], m[2].strip())]
             else:
                 self.ents += [{'href': line, 'attrs': attrs}]
-                attrs = {}
+                attrs = []
 
     def __len__(self):
         return len(self.ents)

--- a/common/m3u.py
+++ b/common/m3u.py
@@ -41,3 +41,11 @@ class M3UPlaylist:
 
     def __getitem__(self, key):
         return self.ents[key]
+
+    @staticmethod
+    def parse_kv_attr(kvs):
+        """ Return a dictionary that is the result of parsing a string consisting of a
+        comma-separated list of `key=value` pairs.
+        """
+        # TODO: improve regex matching of quoted values
+        return {k: v for k, v in re.findall(r'([A-Za-z0-9_-]+)\s*=\s*"?([^"=,]+)"?', kvs)}

--- a/provider/ESatresplayer.py
+++ b/provider/ESatresplayer.py
@@ -1,6 +1,6 @@
 import http.cookiejar, urllib.request, urllib.parse, json
 import os.path, re
-from common.avsource import CurlMpegtsSequenceAVSource
+from common.avsource import CurlMpegtsSequenceMuxAVSource
 from common.m3u import M3UPlaylist
 from common.provider import ContentProvider
 
@@ -58,7 +58,7 @@ class AtresplayerProvider(ContentProvider):
             raise ValueError("'%s': no such entry in the channel list" % resource)
 
         j = json.load(self.http.open(self._URL_STREAM_INFO % ls[resource]['id']))
-        master_m3u8 = j['sources'][0]['src']
+        master_m3u8 = j['sourcesLive'][0]['src']
 
         try:
             return {'title': j['titulo'],
@@ -78,10 +78,30 @@ class AtresplayerProvider(ContentProvider):
                          expectExtm3u=True)
         # Do not rely on the `EXT-X-MEDIA-SEQUENCE` attribute as it has been seen to carry incorrect
         # values; instead use the sequence number in the href string
-        r = re.compile(r'_([0-9]+).ts')
+        r = re.compile(r'-([0-9]+).ts')
         seq = re.search(r, ts[0]['href'])[1]
-        return (prefix + re.sub(r, '_%s.ts', ts[0]['href']),
+        return (prefix + re.sub(r, '-%s.ts', ts[0]['href']),
                 int(seq))
+
+    def collect_audio_playlists(self, masterPlaylist):
+        """
+        Collect all the audio playlists referenced in `masterPlaylist` and return a tuple containing
+        `(audio_playlists, default_idx)`.
+        `audio_playlists` is a list of dictionaries.  Each dictionary is the result of parsing the
+        corresponding list of attributes in the master playlist; the `NAME` and `URI` keys refer to the
+        name and the relative path of the playlist, respectively.
+        """
+        audio_playlists = []
+        default = -1
+        for entry in masterPlaylist:
+            for k, v in entry['attrs']:
+                if k == 'EXT-X-MEDIA':
+                    attr_kv = M3UPlaylist.parse_kv_attr(v)
+                    if attr_kv['TYPE'] == 'AUDIO':
+                        if attr_kv['DEFAULT'] == 'YES':
+                            default = len(audio_playlists)
+                        audio_playlists += [attr_kv]
+        return (audio_playlists, default)
 
     def get_mpegts_url(self, streamInfo, alternative):
         """ Get the base URL and current MPEG TS sequence number.  Specifically,
@@ -90,16 +110,21 @@ class AtresplayerProvider(ContentProvider):
         @param streamInfo Stream information, as returned by `get_stream_info()`
         @param alternative Alternative #.
         @return A dictionary that contains the required data to construct a
-        CurlMpegtsSequenceAVSource instance.
+        CurlMpegtsSequenceMuxAVSource instance.
         """
-        prefix = streamInfo['__prefix']
-        playlistUrl = prefix + streamInfo['alt'][alternative]['href']
-        return self.parse_media_playlist(prefix, playlistUrl)
+        audio_playlists, audio_default = self.collect_audio_playlists(streamInfo['alt'])
+        if audio_default == -1:
+            logging.warning("Couldn't determine the default audio playlist; using 0")
+            audio_default = 0
 
+        prefix = streamInfo['__prefix']
+        video = self.parse_media_playlist(prefix, prefix + streamInfo['alt'][alternative]['href'])
+        audio = self.parse_media_playlist(prefix, prefix + audio_playlists[audio_default]['URI'])
+        return [video, audio]
 
     def get_av_source(self, streamInfo, alternative=-1):
         urlTemplateAndInitSeq = self.get_mpegts_url(streamInfo, alternative)
-        return CurlMpegtsSequenceAVSource(urlTemplateAndInitSeq,
-                                          int(self.params['urls-per-proc']),
-                                          self.params['user-agent'],
-                                          self.cookieJar)
+        return CurlMpegtsSequenceMuxAVSource(urlTemplateAndInitSeq,
+                                             int(self.params['urls-per-proc']),
+                                             self.params['user-agent'],
+                                             self.cookieJar)


### PR DESCRIPTION
Per latest updates to Atresplayer, audio / video streams have been separated.

Specifically, the former `bitrateX/Y-SEQ.ts` fragments now only transport the video stream.  The audio stream is transported separately in a different set of `.ts` files.  In this case, the master playlist references a number of audio playlists, thus making it possible to select alternative audio streams.

Per limitations on the current design, the user cannot manually specify the audio stream to use (ESatresplayer shall use the default in the master playlist).